### PR TITLE
IP Denial - Allow for front end notification

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,7 +29,7 @@ class UsersController < ApplicationController
             end
 
             if cur_ip.count > 2
-                return redirect_to root_path
+                return redirect_to root_path + "?login=fail"
             else
                 cur_ip.count = cur_ip.count + 1
                 cur_ip.save


### PR DESCRIPTION
returning a parameter allows to make some notification on the front end. This way people aren't thinking it's a bug: "page just reloads when entering my email", but because they've already added a max # of emails.
