### PR TITLE
CSV Export - adds referrer

### DIFF
--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -1,16 +1,14 @@
 # Export to CSV with the referrer_id
 ActiveAdmin.register User do
-    csv do
-      column :id
-      column :email
-      column :referral_code
-      column :referrer_id
-      column :created_at
-      column :updated_at
-    end
-end
+  csv do
+    column :id
+    column :email
+    column :referral_code
+    column :referrer_id
+    column :created_at
+    column :updated_at
+  end
 
-# Display Default Index
-ActiveAdmin.register User do
   actions :index, :show
+  
 end


### PR DESCRIPTION
This make the CSV export much much more useful being that it will now have the referrer_id. Now you can just open the CSV in a spreadsheet or processing script and do all the calculations for user earnings.

To note: CSV is the only exportable format that gives you 10,000 rows. Both JSON and XML are limited to 30, so CSV is the most important format to export all the details to.
