### PR TITLE
Small fix in email

### DIFF
--- a/app/views/user_mailer/signup_email.html.erb
+++ b/app/views/user_mailer/signup_email.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns"http//www.w3.org/1999/xhtml" xml:lang="en-us" lang="en-us">
+<html xmlns="http//www.w3.org/1999/xhtml" xml:lang="en-us" lang="en-us">
 <head>
     <meta http-equiv="content-type" content="text/html" charset="utf-8">
     <style type="text/css">


### PR DESCRIPTION
It prevent to see "/www.w3.org/1999/xhtml" xml:lang="en-us" lang="en-us">" in the email sent.
![capture](https://cloud.githubusercontent.com/assets/2980518/6741274/7720dda4-ce86-11e4-88d8-81cd52755513.PNG)
