### PR TITLE
Removes AdminUser creation from migration

### DIFF
--- a/db/migrate/20130127063936_devise_create_admin_users.rb
+++ b/db/migrate/20130127063936_devise_create_admin_users.rb
@@ -1,10 +1,4 @@
 class DeviseCreateAdminUsers < ActiveRecord::Migration
-  def migrate(direction)
-    super
-    # Create a default user
-    AdminUser.create!(:email => 'tech@harrys.com', :password => 'h@rry5t3ch', :password_confirmation => 'h@rry5t3ch') if direction == :up
-  end
-
   def change
     create_table(:admin_users) do |t|
       ## Database authenticatable


### PR DESCRIPTION
This sneaks into production if you're not aware -- better remove it and have the admin users created via the rails console as stated in the README.