### PR TITLE
Features/mailchimp integration

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,5 @@
 DEFAULT_MAILER_HOST="localhost:3000"
 SECRET_KEY_BASE="xxxxxxxx-change-me-please-xxxxxxxx"
 CAMPAIGN_ENDED=false
+LIST_ID="Mailchimp-ID"
+MAILCHIMP_KEY="mailchimp api key"

--- a/Gemfile
+++ b/Gemfile
@@ -41,4 +41,5 @@ end
 group :production do
   gem 'rails_12factor'
   gem 'rails_serve_static_assets'
+  gem 'gibbon'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,9 +85,14 @@ GEM
       railties (>= 4.0, < 5.1)
     erubis (2.7.0)
     execjs (2.6.0)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
     formtastic (3.1.3)
       actionpack (>= 3.2.13)
     formtastic_i18n (0.5.0)
+    gibbon (2.2.4)
+      faraday (>= 0.9.1)
+      multi_json (>= 1.11.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     has_scope (0.6.0)
@@ -118,6 +123,8 @@ GEM
     mime-types (2.99.1)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
+    multi_json (1.11.2)
+    multipart-post (2.0.0)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     orm_adapter (0.5.0)
@@ -229,6 +236,7 @@ DEPENDENCIES
   delayed_job_active_record (~> 4.0.3)
   devise
   dotenv-rails
+  gibbon
   pg
   pry
   rails (= 4.2.5.2)

--- a/README.md
+++ b/README.md
@@ -69,6 +69,19 @@ foreman start -f Procfile.dev
 View your website at the port default `http://localhost:5000/`.
 View sent mails at `http://localhost:1080/`.
 
+### MailChimp integration
+
+If you want to push subscribers to MailChimp. Add the following keys to your `.env` file
+```
+LIST_ID=listID
+MAILCHIMP_KEY=apiKey
+```
+Find your ListID [here](http://kb.mailchimp.com/lists/managing-subscribers/find-your-list-id)
+Find your APIKey [here](http://kb.mailchimp.com/integrations/api-integrations/about-api-keys)
+
+Users will then receive the subscribe to list email from MailChimp (You can modify it there), instead of the welcome email packaged with this application.
+
+This integration adds a verified attribute to the `User` table. in order for the values to update you need to setup a [webhook](http://kb.mailchimp.com/integrations/api-integrations/how-to-set-up-webhooks) that points to `{root_url}/mailchimp/subscriber`, you only need to enable the subscription events.
 ### To create an admin account
 
 In Rails console, run this command. Be careful to not use the example admin user

--- a/app/controllers/mailchimp_controller.rb
+++ b/app/controllers/mailchimp_controller.rb
@@ -1,0 +1,12 @@
+class MailchimpController < ApplicationController
+
+  def subscribed
+    if params["type"] == "subscribe"
+      user = User.where(email:params["data"]["email"]).first
+      user.verified = true
+      user.save
+    end
+    render :json => user
+  end
+
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,7 +18,6 @@ class UsersController < ApplicationController
     email = params[:user][:email]
     @user = User.new(email: email)
     @user.referrer = User.find_by_referral_code(ref_code) if ref_code
-
     if @user.save
       cookies[:h_email] = { value: @user.email }
       redirect_to '/refer-a-friend'

--- a/app/helpers/mailchimp_helper.rb
+++ b/app/helpers/mailchimp_helper.rb
@@ -1,0 +1,7 @@
+require 'gibbon'
+
+module MailchimpHelper
+  def self.add_to_list(user)
+    Gibbon::Request.lists(ENV['LIST_ID']).members.create(body: {email_address: user.email, status: "pending", merge_fields: {FNAME: "First Name", LNAME: "Last Name"}})
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 require 'users_helper'
+require 'mailchimp_helper'
 
 class User < ActiveRecord::Base
   belongs_to :referrer, class_name: 'User', foreign_key: 'referrer_id'
@@ -51,6 +52,10 @@ class User < ActiveRecord::Base
   end
 
   def send_welcome_email
-    UserMailer.delay.signup_email(self)
+    if ENV['LIST_ID']
+      MailchimpHelper.add_to_list self
+    else
+      UserMailer.delay.signup_email(self)
+    end
   end
 end

--- a/config/initializers/gibbon.rb
+++ b/config/initializers/gibbon.rb
@@ -1,0 +1,4 @@
+require 'gibbon'
+
+Gibbon::Request.api_key = ENV['MAILCHIMP_KEY']
+Gibbon::Request.timeout = 15

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Prelaunchr::Application.routes.draw do
 
   root :to => "users#new"
 
+  post 'mailchimp/subscriber' => 'mailchimp#subscribed'
+  get 'mailchimp/subscriber' => 'mailchimp#subscribed'
   post 'users/create' => 'users#create'
   get 'refer-a-friend' => 'users#refer'
   get 'privacy-policy' => 'users#policy'

--- a/db/migrate/20161109160016_add_verified_to_user.rb
+++ b/db/migrate/20161109160016_add_verified_to_user.rb
@@ -1,0 +1,5 @@
+class AddVerifiedToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :verified, :boolean, :default => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20130312045541) do
+ActiveRecord::Schema.define(version: 20161109160016) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,8 +76,9 @@ ActiveRecord::Schema.define(version: 20130312045541) do
     t.string   "email"
     t.string   "referral_code"
     t.integer  "referrer_id"
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
+    t.boolean  "verified",      default: false
   end
 
 end


### PR DESCRIPTION
Hi, this repo was super helpful when creating our prelaunch website. we wanted to integrate with MailChimp.

I added the following features.

- Instead of sending the welcome mail from rails, it gets sent from MailChimp
- Users when users subscribe on MailChimp a webhook updates their User records as verified.

The feature is completely backward compatible, since it is only activated if the developer adds their MailChimp variables to the env file.