### PR TITLE
If user exists redirect to refer-a-friend page

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,5 @@
 class UsersController < ApplicationController
-  before_filter :skip_first_page, only: :new
-  before_filter :handle_ip, only: :create
+  before_action :user_exists, only: :create
   before_action :skip_first_page, only: :new
   before_action :handle_ip, only: :create
 
@@ -22,8 +21,7 @@ class UsersController < ApplicationController
     @user.referrer = User.find_by_referral_code(ref_code) if ref_code
 
     if @user.save
-      cookies[:h_email] = { value: @user.email }
-      redirect_to '/refer-a-friend'
+      set_cookie_and_redirect(@user.email)
     else
       logger.info("Error saving user with email, #{email}")
       redirect_to root_path, alert: 'Something went wrong!'
@@ -53,6 +51,20 @@ class UsersController < ApplicationController
   end
 
   private
+
+  def set_cookie_and_redirect(email)
+    cookies[:h_email] = { value: email }
+    redirect_to '/refer-a-friend'
+  end
+
+  def user_exists
+    email = params[:user][:email].downcase
+    params[:user][:email] = email
+    user = User.find_by_email(email)
+    if not user.nil?
+      set_cookie_and_redirect(user.email)
+    end
+  end
 
   def skip_first_page
     return if Rails.application.config.ended

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,8 @@
 class UsersController < ApplicationController
   before_filter :skip_first_page, only: :new
   before_filter :handle_ip, only: :create
+  before_action :skip_first_page, only: :new
+  before_action :handle_ip, only: :create
 
   def new
     @bodyId = 'home'


### PR DESCRIPTION
Sometimes people use a different computer or cleared cookies. For what ever reason the cookie is not there, they want to see their progress or fetch referral link. This pr adds a `before_action :create` method that will redirect them to the page if they subscribed before. previously a create error would be thrown on `user.save`

it also changes the email to lowercase, user that sign up with mobile browser often use Capitalised, emails, so it is important, to lowercase them for this feature to work.

i also fixed a deprecation